### PR TITLE
fix : npm start 로그에 대한 output 대기 이슈 수정

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -19,7 +19,7 @@ echo "Installing dependencies..."
 sudo -u ec2-user -i bash -c 'cd /opt/gagga-front && npm ci'
 
 echo "Starting React server..."
-sudo -u ec2-user -i bash -c 'cd /opt/gagga-front && nohup npm start > ~/react-ssr.log 2>&1 &'
+sudo -u ec2-user -i bash -c 'cd /opt/gagga-front && nohup npm start > /var/log/react-ssr.log 2>&1 < /dev/null &'
 
 echo $! | sudo tee /var/run/react-app.pid
 


### PR DESCRIPTION
# 작업 내용

- `npm start` 명령어에 대한 output을 로그 파일에 input하는 과정을 백그라운드로 실행함에 따라, 사용자 입력을 무한히 기다리는 이슈가 발생하여, 사용자 입력이 필요한 상황인 경우, 스킵하도록 수정

# 참조

closes #23